### PR TITLE
Fix: Correct API key loading for Vite environment

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -34,20 +34,20 @@ const App: React.FC = () => {
 
 
   useEffect(() => {
-    const keyFromEnv = process.env.API_KEY;
+    const keyFromEnv = import.meta.env.VITE_GEMINI_API_KEY;
     if (keyFromEnv) {
       setApiKey(keyFromEnv);
       setCurrentScreen(AppScreen.ImageUpload); 
     } else {
-      console.error("API Key not found in process.env.API_KEY. The app will not function correctly.");
-      setError("CRITICAL: API Key is not configured. Please ensure the API_KEY environment variable is set. The application cannot operate without it.");
+      console.error("API Key not found in import.meta.env.VITE_GEMINI_API_KEY. The app will not function correctly.");
+      setError("CRITICAL: API Key is not configured. Please ensure the VITE_GEMINI_API_KEY environment variable is set correctly in your .env.local file and that the application has been rebuilt/restarted if changes were made. The application cannot operate without it.");
       setCurrentScreen(AppScreen.Error);
     }
   }, []);
 
   const handleImageUpload = useCallback(async (imageDataUrls: string[]) => {
     if (!apiKey) {
-      setError("API Key is not configured. Cannot proceed.");
+      setError("API Key is not configured. Cannot proceed. Ensure VITE_GEMINI_API_KEY is set.");
       setCurrentScreen(AppScreen.Error);
       return;
     }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
+2. Create a `.env.local` file in the root of the project.
+3. Add your Gemini API key to the `.env.local` file like this:
+   `VITE_GEMINI_API_KEY=YOUR_API_KEY_HERE`
+   Replace `YOUR_API_KEY_HERE` with your actual Gemini API key.
+4. Run the app:
    `npm run dev`


### PR DESCRIPTION
- Updated App.tsx to use `import.meta.env.VITE_GEMINI_API_KEY` instead of `process.env.API_KEY` to correctly load the Gemini API key in a Vite client-side application.
- Updated error messages in App.tsx to refer to the correct environment variable name and provide clearer guidance.
- Updated README.md to instruct users to set `VITE_GEMINI_API_KEY` in their `.env.local` file.

This change addresses a critical issue where the application would fail to load the API key, rendering AI-dependent features unusable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup instructions in the README to clarify how to configure the Gemini API key using the correct environment variable.
- **Bug Fixes**
  - Improved error messages to reference the correct environment variable for the API key and provide clearer guidance when the key is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->